### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A **Model Context Protocol (MCP)** server that integrates [Piper TTS](https://github.com/rhasspy/piper) for high-quality text-to-speech functionality. This server provides a `speak` tool that converts text to speech and plays it directly through your speakers with customizable volume control.
 
+<a href="https://glama.ai/mcp/servers/@CryptoDappDev/piper-tts-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CryptoDappDev/piper-tts-mcp/badge" alt="Piper TTS Server MCP server" />
+</a>
+
 ## ✨ Features
 
 - 🔊 **High-quality text-to-speech** using Piper TTS


### PR DESCRIPTION
This PR adds a badge for the [Piper TTS MCP Server](https://glama.ai/mcp/servers/@CryptoDappDev/piper-tts-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@CryptoDappDev/piper-tts-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CryptoDappDev/piper-tts-mcp/badge" alt="Piper TTS Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.